### PR TITLE
Replaced AND/OR Labels with Helper Messages in Filter Section for Improved Clarity

### DIFF
--- a/Streamlit/Streamlit.py
+++ b/Streamlit/Streamlit.py
@@ -841,17 +841,18 @@ def streamlitSideBar(file):
     licensedContent = np.append(licensedContent, 'All')
     licensedContent = licensedContent.astype(str)
 
-
+    st.sidebar.write("Please select at least one of the following: Continent, Country, or Channel")
     FilterContinents = st.sidebar.multiselect("Select Continents", options = continents, default = 'All')
-    st.sidebar.write("OR")
+    # st.sidebar.write("OR")
     FilterCountries = st.sidebar.multiselect("Select Countries", options = countries, default = 'All')
-    st.sidebar.write("OR")
+    # st.sidebar.write("OR")
     FilterChannelNames = st.sidebar.multiselect("Select Channels", options = channelNames, default = 'All' )
-    st.sidebar.write("AND")
+    # st.sidebar.write("AND")
+    st.sidebar.write("Please select at least one year to proceed")
     FilterYears = st.sidebar.multiselect("Select Years", options = Years, default = 'All')
-    st.sidebar.write("AND")
+    # st.sidebar.write("AND")
     FilterCategory = st.sidebar.radio("Select Category", options  = category, index=len(category) - 1)
-    st.sidebar.write("AND")
+    # st.sidebar.write("AND")
     FilterLicensedContent = st.sidebar.radio("Select Licensed Content", options = licensedContent, index=len(category) - 1)
     
     return FilterContinents, FilterCountries, FilterCategory, FilterYears, FilterChannelNames, FilterLicensedContent


### PR DESCRIPTION
### 📌 Summary

This PR improves the filter section UI in the Streamlit app by addressing user confusion around the logical filter structure. The original implementation displayed "AND"/"OR" labels between filter groups, which led to misunderstandings. These have now been commented out and replaced with user-friendly helper messages.

---

### ✅ Changes Made

- 💬 **Commented out** all `st.write()` lines displaying “AND” / “OR” between filter sections.
- 📝 **Added helper message** above the **Continent** filter:  
  _“Please select at least one of the following: Continent, Country, or Channel”_
- 📅 **Added helper message** above the **Years** filter:  
  _“Please select at least one year to proceed”_
- ✍️ **No grouping** of filters was made (e.g., no “Location Filters” section) since `Channel` does not logically belong with `Continent` or `Country`.
- 🛡️ Ensured validation logic is maintained (or planned) to enforce the required selections from:
  - At least one of: Continent / Country / Channel
  - At least one Year

---

### 💡 Why These Changes?

- Makes filter requirements clearer without exposing backend logical operators to users.
- Avoids misleading groupings by keeping filters in their current layout.
- Preserves a clean and intuitive UI with minimal disruption.

---

### 🧪 Testing

- Verified that helper messages appear as expected in the UI.
- Validated that users are guided properly when interacting with the filters.
- Checked for visual clarity and spacing around new helper text.

---

### 🧩 Related Issue

Closes: #28  
Addresses user feedback regarding confusion with AND/OR filter logic.
